### PR TITLE
Temp: Change HEMCO subroutine calls to HEMCO 3.0 format.

### DIFF
--- a/GeosCore/aerosol_mod.F
+++ b/GeosCore/aerosol_mod.F
@@ -430,7 +430,7 @@
          ELSE IF ( MONTH == 9  .or. MONTH == 10 .or. MONTH == 11 ) THEN
             FieldName = 'OMOC_SON'
          ENDIF
-         CALL HCO_GetPtr( am_I_Root, HcoState, FIELDNAME, OMOC, RC,
+         call HCO_GetPtr(  HcoState, FIELDNAME, OMOC, RC,
      &                    FOUND=FND )
 
          ! Trap potential errors

--- a/GeosCore/carbon_mod.F
+++ b/GeosCore/carbon_mod.F
@@ -568,15 +568,15 @@
 
             IF ( LSOA ) THEN
                ! Get offline oxidant fields from HEMCO (mps, 9/23/14)
-               CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_OH',  OH,  RC )
+               call HCO_GetPtr( HcoState, 'GLOBAL_OH',  OH,  RC )
                IF ( RC /= GC_SUCCESS )
      &         CALL ERROR_STOP( 'Cannot get pointer to GLOBAL_OH',  LOC)
 
-               CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_NO3', NO3, RC )
+               call HCO_GetPtr( HcoState, 'GLOBAL_NO3', NO3, RC )
                IF ( RC /= GC_SUCCESS )
      &         CALL ERROR_STOP( 'Cannot get pointer to GLOBAL_NO3', LOC)
 
-               CALL HCO_GetPtr( aIR, HcoState, 'O3',         O3,  RC )
+               call HCO_GetPtr( HcoState, 'O3',         O3,  RC )
                IF ( RC /= GC_SUCCESS )
      &         CALL ERROR_STOP( 'Cannot get pointer to O3',         LOC)
             ENDIF
@@ -5533,7 +5533,7 @@ ccc
       ! (ramnarine 12/27/2018)
       IF ( FIRST ) THEN
          ! Get a pointer to the fire number field if in use
-         CALL HCO_GetPtr( am_I_root, HcoState, 'FINN_DAILY_NUMBER',
+         call HCO_GetPtr(  HcoState, 'FINN_DAILY_NUMBER',
      &        FIRE_NUM, RC, FOUND=FND )
             !if biomass burning subgrid coagulation is in use,
             !FIRE_NUM will not be NULL() and therefore will not be ASSOCIATED()

--- a/GeosCore/co2_mod.F
+++ b/GeosCore/co2_mod.F
@@ -317,7 +317,7 @@
          ! Get a pointer to the CO2 production from CO oxidation
          ! This is now listed in the NON-EMISSIONS DATA section of
          ! the HEMCO configuration file. (bmy, 4/17/15)
-         CALL HCO_GetPtr( am_I_Root,   HcoState, 
+         call HCO_GetPtr(    HcoState, 
      &                   'CO2_COPROD', CO2_COPROD, RC )
 
          IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/get_met_mod.F90
+++ b/GeosCore/get_met_mod.F90
@@ -106,7 +106,7 @@ CONTAINS
     ENDIF
 
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( am_I_Root, HcoState, v_name, Ptr2D, RC, TIDX=T, &
+    call HCO_GetPtr(  HcoState, v_name, Ptr2D, RC, TIDX=T, &
                      FOUND=FND )
 
       ! Stop with error message
@@ -194,7 +194,7 @@ CONTAINS
     ENDIF
     
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( am_I_Root, HcoState, v_name, Ptr3D, RC, TIDX=T, &
+    call HCO_GetPtr(  HcoState, v_name, Ptr3D, RC, TIDX=T, &
                      FOUND=FND )
 
       ! Stop with error message
@@ -282,7 +282,7 @@ CONTAINS
     ENDIF
 
     ! Get the pointer to the data in the HEMCO data structure
-    CALL HCO_GetPtr( am_I_Root, HcoState, v_name, Ptr3D, RC, TIDX=T, &
+    call HCO_GetPtr(  HcoState, v_name, Ptr3D, RC, TIDX=T, &
                      FOUND=FND )
 
       ! Stop with error message

--- a/GeosCore/global_br_mod.F
+++ b/GeosCore/global_br_mod.F
@@ -189,7 +189,7 @@
          !-----------------------------------------------------------------
 
          ! Get a pointer to the the GEOS-Chem Br from HEMCO (bmy, 3/11/15)
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'Br_GC', Br_GC,  RC )
+         call HCO_GetPtr(  HcoState, 'Br_GC', Br_GC,  RC )
 
          ! Trap potential errors
          IF ( RC /= GC_SUCCESS ) THEN
@@ -206,7 +206,7 @@
          !-----------------------------------------------------------------
 
          ! Get a pointer to the GEOS-Chem BrO from HEMCO (bmy, 3/11/15)
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'BrO_GC', BrO_GC, RC )
+         call HCO_GetPtr(  HcoState, 'BrO_GC', BrO_GC, RC )
 
          ! Trap potential errors
          IF ( RC /= GC_SUCCESS ) THEN
@@ -225,7 +225,7 @@
          !-----------------------------------------------------------------
 
          ! Get a pointer to the TOMCAT Br from HEMCO (bmy, 3/11/15)
-         CALL HCO_GetPtr( am_I_Root,  HcoState, 
+         call HCO_GetPtr(   HcoState, 
      &                   'Br_TOMCAT', Br_TOMCAT, RC )
 
          ! Trap potential errors
@@ -243,7 +243,7 @@
          !-----------------------------------------------------------------
 
          ! Get a pointer to the TOMCAT Br from HEMCO (bmy, 3/11/15)
-         CALL HCO_GetPtr( am_I_Root,   HcoState, 
+         call HCO_GetPtr(    HcoState, 
      &                   'BrO_TOMCAT', BrO_TOMCAT, RC )
 
          ! Trap potential errors
@@ -263,7 +263,7 @@
       !-----------------------------------------------------------------
 
       ! Get a pointer to the GMI Br from HEMCO (bmy, 3/11/15)
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'Br_GMI', Br_GMI, RC )
+      call HCO_GetPtr(  HcoState, 'Br_GMI', Br_GMI, RC )
 
       ! Trap potential errors
       IF ( RC /= GC_SUCCESS ) THEN
@@ -280,7 +280,7 @@
       !-----------------------------------------------------------------
 
       ! Get a pointer to the GMI Br from HEMCO (bmy, 3/11/15)
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'BrO_GMI', BrO_GMI, RC )
+      call HCO_GetPtr(  HcoState, 'BrO_GMI', BrO_GMI, RC )
 
       ! Trap potential errors
       IF ( RC /= GC_SUCCESS ) THEN
@@ -329,7 +329,7 @@
 !$OMP END PARALLEL DO
 
       ! Get a pointer to the GMI Br from HEMCO (bmy, 3/11/15)
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'JBrO', JBrO, RC )
+      call HCO_GetPtr(  HcoState, 'JBrO', JBrO, RC )
 
       ! Trap potential errors
       IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/global_ch4_mod.F
+++ b/GeosCore/global_ch4_mod.F
@@ -820,7 +820,7 @@
 
          ! Import CH4 loss frequencies from HEMCO. The target will be 
          ! updated automatically by HEMCO (ckeller, 9/16/2014)
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'CH4_LOSS', CH4LOSS, RC )
+         call HCO_GetPtr(  HcoState, 'CH4_LOSS', CH4LOSS, RC )
 
          ! Trap potential errors
          IF ( RC /= HCO_SUCCESS ) THEN
@@ -837,7 +837,7 @@
       IF ( FIRSTCHEM ) THEN
 
          ! Get pointer to GLOBAL_OH
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OH', BOH, RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OH', BOH, RC )
 
          ! Trap potential errors
          IF ( RC /= HCO_SUCCESS ) THEN
@@ -847,7 +847,7 @@
          ENDIF 
 
          ! Get pointer to GLOBAL_Cl
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_Cl', BCl, RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_Cl', BCl, RC )
 
          ! Trap potential errors
          IF ( RC /= HCO_SUCCESS ) THEN

--- a/GeosCore/hco_interface_mod.F90
+++ b/GeosCore/hco_interface_mod.F90
@@ -106,8 +106,9 @@ CONTAINS
 !
 ! LOCAL VARIABLES:
 !
-    INTEGER  :: cYr, cMt, cDy, cHr, cMin, cSec, cDOY 
+    INTEGER  :: cYr, cMt, cDy, cHr, cMin, cSec, cDOY
 
+#if !defined( MODEL_CESM )
     !=================================================================
     ! SetHcoTime begins here
     !=================================================================
@@ -122,6 +123,7 @@ CONTAINS
 
     CALL HcoClock_Set ( am_I_Root,  HcoState, cYr, cMt, cDy, cHr, &
                         cMin, cSec, cDoy, IsEmisTime=TimeForEmis, RC=RC )
+#endif
 
   END SUBROUTINE SetHcoTime
 !EOC
@@ -165,6 +167,7 @@ CONTAINS
 !BOC
     INTEGER   :: HcoID, tID
 
+#if !defined( MODEL_CESM )
     !=================================================================
     ! GetHcoVal begins here
     !=================================================================
@@ -195,6 +198,7 @@ CONTAINS
           ENDIF
        ENDIF
     ENDIF
+#endif
 
   END SUBROUTINE GetHcoVal
 !EOC
@@ -305,6 +309,7 @@ CONTAINS
     CHARACTER(LEN=255) :: ErrMsg
     CHARACTER(LEN=255) :: ThisLoc
 
+#if !defined( MODEL_CESM )
     !=======================================================================
     ! GetHcoDiagn begins here 
     !=======================================================================
@@ -386,6 +391,7 @@ CONTAINS
 
     ! Free pointer
     DgnCont  => NULL()
+#endif
 
     ! Leave with success 
     RC = HCO_SUCCESS

--- a/GeosCore/hcoi_gc_main_mod.F90
+++ b/GeosCore/hcoi_gc_main_mod.F90
@@ -3687,7 +3687,7 @@ CONTAINS
       v_name = 'TMPU'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
       
       ! Check if variable is in file
@@ -3713,7 +3713,7 @@ CONTAINS
       v_name = 'SPHU'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -3739,7 +3739,7 @@ CONTAINS
       v_name = 'PSWET'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr2D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -3765,7 +3765,7 @@ CONTAINS
       v_name = 'PSDRY'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr2D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -3791,7 +3791,7 @@ CONTAINS
       v_name = 'DELPDRY'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4043,7 +4043,7 @@ CONTAINS
       Ptr3D => Temp3D
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D,     RC,       FOUND=FOUND )
 
       ! Check if species data is in file
@@ -4363,7 +4363,7 @@ CONTAINS
       v_name = 'KPP_HVALUE'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4396,7 +4396,7 @@ CONTAINS
       v_name = 'WETDEP_N'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr2D,     RC,       FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4422,7 +4422,7 @@ CONTAINS
       v_name = 'DRYDEP_N'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr2D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4456,7 +4456,7 @@ CONTAINS
       v_name = 'H2O2_AFTERCHEM'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4482,7 +4482,7 @@ CONTAINS
       v_name = 'SO2_AFTERCHEM'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D, RC, FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4515,7 +4515,7 @@ CONTAINS
       v_name = 'STATE_PSC'
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D,     RC,       FOUND=FOUND )
 
       ! Check if variable is in file
@@ -4577,7 +4577,7 @@ CONTAINS
          v_name = 'OCEAN_' // TRIM( HgSpc )
 
          ! Get variable from HEMCO and store in local array
-         CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+         call HCO_GetPtr(  HcoState, TRIM(v_name), &
                           Ptr2D, RC, FOUND=FOUND )
 
          ! Check if variable is in file
@@ -4637,7 +4637,7 @@ CONTAINS
                         '_'      // TRIM( Hg_Cat_Name(N) )
 
                ! Get variable from HEMCO and store in local array
-               CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+               call HCO_GetPtr(  HcoState, TRIM(v_name), &
                                 Ptr2D, RC, FOUND=FOUND )
 
                ! Check if variable is in file
@@ -4703,7 +4703,7 @@ CONTAINS
             ENDIF
 
             ! Get variable from HEMCO and store in local array
-            CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+            call HCO_GetPtr(  HcoState, TRIM(v_name), &
                              Ptr2D, RC, FOUND=FOUND )
 
             ! Check if variable is in file
@@ -4889,7 +4889,7 @@ CONTAINS
       Ptr3D => Temp3D
 
       ! Get variable from HEMCO and store in local array
-      CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(v_name), &
+      call HCO_GetPtr(  HcoState, TRIM(v_name), &
                        Ptr3D,     RC,       FOUND=FOUND )
 
       ! Check if BCs are found

--- a/GeosCore/isorropiaII_mod.F
+++ b/GeosCore/isorropiaII_mod.F
@@ -351,7 +351,7 @@
             ELSE IF ( IT_IS_AN_AEROSOL_SIM ) THEN
 
                ! Offline simulation: get HNO3 from HEMCO (mps, 9/23/14)
-               CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_HNO3', HNO3, RC )
+               CALL HCO_GetPtr( HcoState, 'GLOBAL_HNO3', HNO3, RC )
                IF ( RC /= GC_SUCCESS ) THEN
                   ErrMsg = 
      &              'Cannot get pointer to HEMCO field GLOBAL_HNO3!'

--- a/GeosCore/mercury_mod.F
+++ b/GeosCore/mercury_mod.F
@@ -681,7 +681,7 @@
 
          !-----------------------------------------------------------
          ! Some oxidants always required:
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OH_trop',
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OH_trop',
      &                    OH_trop,   RC                           )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OH_trop!'
@@ -689,7 +689,7 @@
             RETURN
          ENDIF
 
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OH_strat',
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OH_strat',
      &                    OH_strat,  RC                           )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OH_strat!'
@@ -697,7 +697,7 @@
             RETURN
          ENDIF
 
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_O3', 
+         call HCO_GetPtr(  HcoState, 'GLOBAL_O3', 
      &                    O3,        RC                           )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_O3!'
@@ -720,7 +720,7 @@
          ! Some oxidants only required by certain mechanisms:
          !-------------------------------------------------------------
          IF ( LHALOGENCHEM ) THEN
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_NO2', 
+            call HCO_GetPtr(  HcoState,'GLOBAL_NO2', 
      &           HEM_NO2, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_NO2!'
@@ -728,7 +728,7 @@
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_NO', 
+            call HCO_GetPtr(  HcoState,'GLOBAL_NO', 
      &           HEM_NO, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_NO!'
@@ -736,7 +736,7 @@
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_HO2_trop',
+            call HCO_GetPtr(  HcoState,'GLOBAL_HO2_trop',
      &           HEM_HO2_trop, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_HO2_trop!'
@@ -744,7 +744,7 @@
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_HO2_strat',
+            call HCO_GetPtr(  HcoState,'GLOBAL_HO2_strat',
      &           HEM_HO2_strat, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_HO2_strat!'
@@ -752,7 +752,7 @@
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_ClO',
+            call HCO_GetPtr(  HcoState,'GLOBAL_ClO',
      &           HEM_CLO, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_ClO!'
@@ -760,7 +760,7 @@
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_Cl',
+            call HCO_GetPtr(  HcoState,'GLOBAL_Cl',
      &           HEM_CL, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_NO2!'
@@ -772,7 +772,7 @@
          !-------------------------------------------------------------
 
          IF ( LHGAQCHEM ) THEN
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_HOCl', 
+            call HCO_GetPtr(  HcoState,'GLOBAL_HOCl', 
      &           HEM_HOCL, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_HOCl!'
@@ -784,14 +784,14 @@
          !-------------------------------------------------------------
 
          IF ( LRED_JNO2 ) THEN
-            CALL HCO_GetPtr( am_I_Root, HcoState, 'JNO2', JNO2,  RC )
+            call HCO_GetPtr(  HcoState, 'JNO2', JNO2,  RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to JNO2!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( am_I_Root, HcoState,'GLOBAL_OA',
+            call HCO_GetPtr(  HcoState,'GLOBAL_OA',
      &        HEM_OA, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_OA!'
@@ -4614,7 +4614,7 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       Ptr2D    => NULL()
 
       ! Soil distribution 
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'HG0_SOILDIST', Ptr2D, RC )
+      call HCO_GetPtr(  HcoState, 'HG0_SOILDIST', Ptr2D, RC )
       IF ( RC /= HCO_SUCCESS ) THEN
          ErrMsg = 'Could not get pointer to HEMCO field HG0_SOILDIST!'
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -6302,7 +6302,7 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
       E_ELEC_Hg2 => NULL()
 
       ! Get a pointer to the monthly mean OH from HEMCO (bmy, 3/11/15)
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                'CFPP_NEI2005_Hg2', E_ELEC_Hg2, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 
@@ -6483,7 +6483,7 @@ c$$$         k3ano2 = 3.4d-12 * exp(391d0/T)
 
       IF ( ITS_A_NEW_MONTH() ) THEN 
       
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OCEAN', 
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OCEAN', 
      &                    OCEAN_CONC,  RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to HEMCO field GLOBAL_OCEAN!'

--- a/GeosCore/modis_lai_mod.F90
+++ b/GeosCore/modis_lai_mod.F90
@@ -140,7 +140,7 @@ CONTAINS
        ! (variable names are XLAI00, XLAI01, .. XLAI72)
        WRITE( Name, 100 ) T-1
  100   FORMAT( 'XLAI' , i2.2 )
-       CALL HCO_GetPtr( am_I_Root, HcoState, Name, Ptr2D, RC )
+       call HCO_GetPtr(  HcoState, Name, Ptr2D, RC )
 
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/ocean_mercury_mod.F
+++ b/GeosCore/ocean_mercury_mod.F
@@ -494,7 +494,7 @@
       !---------------------------
       ! Read SO4 from HEMCO
       !---------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_SO4', ARRAYso4, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_SO4', ARRAYso4, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_SO4', LOC )
       ENDIF
@@ -506,7 +506,7 @@
       !---------------------------
       ! Read NH4 from HEMCO
       !---------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_NH4', ARRAYnh4, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_NH4', ARRAYnh4, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_SO4', LOC )
       ENDIF
@@ -518,7 +518,7 @@
       !---------------------------
       ! Read NIT from HEMCO
       !---------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_NIT', ARRAYnit, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_NIT', ARRAYnit, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_SO4', LOC )
       ENDIF
@@ -532,13 +532,13 @@
       !---------------------------
 
       ! BCPI
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_BCPI', ARRAYbcpi, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_BCPI', ARRAYbcpi, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_BCPI', LOC )
       ENDIF
 
       ! BCPO
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_BCPO', ARRAYbcpo, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_BCPO', ARRAYbcpo, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_BCPO', LOC )
       ENDIF
@@ -558,13 +558,13 @@
       !---------------------------
 
       ! OCPI
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_OCPI', ARRAYocpi, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_OCPI', ARRAYocpi, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_OCPI', LOC )
       ENDIF
 
       ! OCPO
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_OCPO', ARRAYocpo, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_OCPO', ARRAYocpo, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_OCPO', LOC )
       ENDIF
@@ -582,7 +582,7 @@
       !---------------------------
       ! Read DST1 from HEMCO
       !---------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'AERO_DST1', ARRAYdst1, RC )
+      call HCO_GetPtr(  HcoState, 'AERO_DST1', ARRAYdst1, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to AERO_DST1', LOC )
       ENDIF
@@ -1212,13 +1212,13 @@
       IF ( LKRedUV ) THEN
 
          ! TOMS O3 columns [dobsons]
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'TOMS_O3_COL', TOMS, RC )
+         call HCO_GetPtr(  HcoState, 'TOMS_O3_COL', TOMS, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             CALL ERROR_STOP ( 'Cannot get pointer to TOMS_O3_COL', LOC )
          ENDIF
    
          ! TOMS O3 columns, present-day [dobsons]
-         CALL HCO_GetPtr( am_I_Root,   HcoState, 
+         call HCO_GetPtr(    HcoState, 
      &                   'TOMS_O3_PD', TOMS_PD, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             CALL ERROR_STOP ( 'Cannot get pointer to TOMSPD_O3_COL', 
@@ -1226,7 +1226,7 @@
          ENDIF
    
          ! TOMS O3 columns, long-term [dobsons]
-         CALL HCO_GetPtr( am_I_Root,   HcoState, 
+         call HCO_GetPtr(    HcoState, 
      &                   'TOMS_O3_LT', TOMS_LT, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             CALL ERROR_STOP ( 'Cannot get pointer to TOMSLT_O3_COL', 
@@ -2503,7 +2503,7 @@
       !-----------------------------------------------------------------
       ! Mixed layer depth [cm]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_MLD', MLD, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_MLD', MLD, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_MLD', LOC )
       ENDIF
@@ -2514,7 +2514,7 @@
       !-----------------------------------------------------------------
       ! Chl from Modis [kg/m3] --> [mg/m3]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_CHLA', CHL, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_CHLA', CHL, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_CHLA', LOC )
       ENDIF
@@ -2525,7 +2525,7 @@
       !-----------------------------------------------------------------
       ! Arctic Chl from Jin et al 2012 [mg/m3]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_CHLA_A', CHL_A, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_CHLA_A', CHL_A, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_ACHLA', LOC )
       ENDIF
@@ -2533,7 +2533,7 @@
       !-----------------------------------------------------------------
       ! Net primary productivity [kg/m2] -> [mg/m2]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_NPP', NPP, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_NPP', NPP, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_NPP', LOC )
       ENDIF
@@ -2544,7 +2544,7 @@
       !-----------------------------------------------------------------
       ! Arctic Net primary productivity [mg/m2/day]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_NPP_A', NPP_A, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_NPP_A', NPP_A, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_ANPP', LOC )
       ENDIF
@@ -2552,7 +2552,7 @@
       !-----------------------------------------------------------------
       ! Ekman upwelling velocity [m/s]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_EKMAN_V', UPVEL, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_EKMAN_V', UPVEL, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to OCEAN_EKMAN_V', LOC )
       ENDIF
@@ -2560,7 +2560,7 @@
       !-----------------------------------------------------------------
       ! MLD tendency, first half of month [cm/s]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_dMLD1', dMLD1, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_dMLD1', dMLD1, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to dMLD1', LOC )
       ENDIF
@@ -2571,7 +2571,7 @@
       !-----------------------------------------------------------------
       ! MLD tendency, second half of month [cm/s]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'OCEAN_dMLD2', dMLD2, RC )
+      call HCO_GetPtr(  HcoState, 'OCEAN_dMLD2', dMLD2, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          CALL ERROR_STOP ( 'Cannot get pointer to dMLD2', LOC )
       ENDIF

--- a/GeosCore/olson_landmap_mod.F90
+++ b/GeosCore/olson_landmap_mod.F90
@@ -423,7 +423,7 @@ CONTAINS
        ! (variable names are LANDTYPE00, LANDTYPE01 .. LANDTYPE72)
        WRITE( Name, 100 ) T-1
  100   FORMAT( 'LANDTYPE', i2.2 )
-       CALL HCO_GetPtr( am_I_Root, HcoState, Name, Ptr2D, RC )
+       call HCO_GetPtr(  HcoState, Name, Ptr2D, RC )
        
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN

--- a/GeosCore/pops_mod.F
+++ b/GeosCore/pops_mod.F
@@ -609,7 +609,7 @@
       IF ( FIRST ) THEN
 
          ! OC
-         CALL HCO_GetPtr( am_I_root, HcoState, 'GLOBAL_OC', C_OC, RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OC', C_OC, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OC!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -617,7 +617,7 @@
          ENDIF
 
          ! BC
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_BC', C_BC, RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_BC', C_BC, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_BC!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -625,7 +625,7 @@
          ENDIF
 
          ! OH
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OH', OH,   RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OH', OH,   RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OC!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -633,7 +633,7 @@
          ENDIF
 
          ! O3
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_O3', O3,   RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_O3', O3,   RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OC!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/rpmares_mod.F
+++ b/GeosCore/rpmares_mod.F
@@ -225,7 +225,7 @@
             ELSE IF ( Input_Opt%ITS_AN_AEROSOL_SIM ) THEN
 
                ! Offline simulation: get HNO3 from HEMCO (mps, 9/23/14)
-               CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_HNO3', HNO3, RC )
+               CALL HCO_GetPtr( HcoState, 'GLOBAL_HNO3', HNO3, RC )
                IF ( RC /= GC_SUCCESS ) 
      &         CALL ERROR_STOP( 'Cannot get pointer to GLOBAL_HNO3', X )
 

--- a/GeosCore/rrtmg_rad_transfer_mod.F
+++ b/GeosCore/rrtmg_rad_transfer_mod.F
@@ -2288,7 +2288,7 @@
       ! CCl4 [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_CCL4'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, CCL4CLIM,  RC )
+      call HCO_GetPtr(  HcoState, FieldName, CCL4CLIM,  RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2299,7 +2299,7 @@
       ! CFC11 [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_CFC11'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, CFC11CLIM, RC )
+      call HCO_GetPtr(  HcoState, FieldName, CFC11CLIM, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2310,7 +2310,7 @@
       ! CFC12 [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_CFC12'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, CFC12CLIM, RC  )
+      call HCO_GetPtr(  HcoState, FieldName, CFC12CLIM, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2321,7 +2321,7 @@
       ! CFC22 [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_CFC22'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, CFC22CLIM, RC  )
+      call HCO_GetPtr(  HcoState, FieldName, CFC22CLIM, RC  )
 
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2333,7 +2333,7 @@
       ! CH4 [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_CH4'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, CH4CLIM,   RC  )
+      call HCO_GetPtr(  HcoState, FieldName, CH4CLIM,   RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2344,7 +2344,7 @@
       ! N2O [ppb]
       !-------------------------------
       FieldName = 'TES_CLIM_N2O'
-      CALL HCO_GetPtr( am_I_Root, HcoState, FieldName, N2OCLIM,   RC  )
+      call HCO_GetPtr(  HcoState, FieldName, N2OCLIM,   RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -2355,7 +2355,7 @@
       ! Diffuse Near-IR albedo [1]
       !-------------------------------
       FieldName = 'MODIS_ALBDFNIR'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_ALBDFNIR, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2367,7 +2367,7 @@
       ! Diffuse visible albedo [1]
       !-------------------------------
       FieldName = 'MODIS_ALBDFVIS'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_ALBDFVIS, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2379,7 +2379,7 @@
       ! Direct Near-IR albedo [1]
       !-------------------------------
       FieldName = 'MODIS_ALBDRNIR'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_ALBDRNIR, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2391,7 +2391,7 @@
       ! Direct visible albedo [1]
       !-------------------------------
       FieldName = 'MODIS_ALBDRVIS'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_ALBDRVIS, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2403,7 +2403,7 @@
       ! MODIS emissivity, band 1 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_01'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_01, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2415,7 +2415,7 @@
       ! MODIS emissivity, band 2 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_02'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_02, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2427,7 +2427,7 @@
       ! MODIS emissivity, band 3 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_03'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_03, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2439,7 +2439,7 @@
       ! MODIS emissivity, band 4 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_04'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_04, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2451,7 +2451,7 @@
       ! MODIS emissivity, band 5 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_05'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_05, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2463,7 +2463,7 @@
       ! MODIS emissivity, band 6 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_06'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_06, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2475,7 +2475,7 @@
       ! MODIS emissivity, band 7 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_07'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_07, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2487,7 +2487,7 @@
       ! MODIS emissivity, band 8 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_08'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_08, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2499,7 +2499,7 @@
       ! MODIS emissivity, band 9 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_09'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_09, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2511,7 +2511,7 @@
       ! MODIS emissivity, band 10 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_10'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_10, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2523,7 +2523,7 @@
       ! MODIS emissivity, band 11 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_11'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_11, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2535,7 +2535,7 @@
       ! MODIS emissivity, band 12 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_12'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_12, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2547,7 +2547,7 @@
       ! MODIS emissivity, band 13 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_13'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_13, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2559,7 +2559,7 @@
       ! MODIS emissivity, band 14 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_14'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_14, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2571,7 +2571,7 @@
       ! MODIS emissivity, band 15 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_15'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_15, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )
@@ -2583,7 +2583,7 @@
       ! MODIS emissivity, band 16 [1]
       !-------------------------------
       FieldName = 'MODIS_EMISSIVITY_16'
-      CALL HCO_GetPtr( am_I_Root, HcoState, 
+      call HCO_GetPtr(  HcoState, 
      &                 FieldName, MODIS_EMISS_16, RC  )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to ' // TRIM( FieldName )

--- a/GeosCore/set_global_ch4_mod.F90
+++ b/GeosCore/set_global_ch4_mod.F90
@@ -143,7 +143,7 @@ CONTAINS
        id_CH4 = Ind_( 'CH4' )
 
        ! Get pointer to surface CH4 data
-       CALL HCO_GetPtr( am_I_Root, HcoState, 'NOAA_GMD_CH4', SFC_CH4, RC )
+       call HCO_GetPtr(  HcoState, 'NOAA_GMD_CH4', SFC_CH4, RC )
        IF ( RC /= GC_SUCCESS ) THEN
           ErrMsg = 'Cannot get pointer to NOAA_GMD_CH4!'
           CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/strat_chem_mod.F90
+++ b/GeosCore/strat_chem_mod.F90
@@ -1024,7 +1024,7 @@ CONTAINS
 
        ! Day
        FIELDNAME = TRIM(PREFIX) // '_DAY'
-       CALL HCO_GetPtr( am_I_Root, HcoState, FIELDNAME, BrPtrDay(N)%MR, RC )
+       call HCO_GetPtr(  HcoState, FIELDNAME, BrPtrDay(N)%MR, RC )
 
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN
@@ -1038,7 +1038,7 @@ CONTAINS
 
        ! Night
        FIELDNAME = TRIM(PREFIX) // '_NIGHT'
-       CALL HCO_GetPtr( am_I_Root, HcoState, FIELDNAME, BrPtrNight(N)%MR, RC )
+       call HCO_GetPtr(  HcoState, FIELDNAME, BrPtrNight(N)%MR, RC )
 
        ! Trap potential errors
        IF ( RC /= GC_SUCCESS ) THEN
@@ -1150,7 +1150,7 @@ CONTAINS
        ENDIF
 
        ! Get pointer from HEMCO
-       CALL HCO_GetPtr( am_I_Root,     HcoState, FIELDNAME, &
+       call HCO_GetPtr(      HcoState, FIELDNAME, &
                         PLVEC(N)%PROD, RC,       FOUND=FND )
 
        ! Trap potential errors
@@ -1180,7 +1180,7 @@ CONTAINS
        ENDIF
 
        ! Get pointer from HEMCO
-       CALL HCO_GetPtr( am_I_Root,     HcoState, FIELDNAME, &
+       call HCO_GetPtr(      HcoState, FIELDNAME, &
                         PLVEC(N)%LOSS, RC,       FOUND=FND )
 
        ! Trap potential errors
@@ -1205,7 +1205,7 @@ CONTAINS
     ENDDO !N
 
     ! Get pointer to STRAT_OH
-    CALL HCO_GetPtr( am_I_Root, HcoState, 'STRAT_OH', &
+    call HCO_GetPtr(  HcoState, 'STRAT_OH', &
                      STRAT_OH,  RC,        FOUND=FND )
 
     ! Trap potential errors

--- a/GeosCore/sulfate_mod.F
+++ b/GeosCore/sulfate_mod.F
@@ -490,42 +490,42 @@
          ! Get offline oxidant fields from HEMCO (mps, 9/18/14)
          IF ( FIRSTCHEM ) THEN
 
-            CALL HCO_GetPtr( aIR, HcoState, 'O3', O3m, RC )
+            call HCO_GetPtr( HcoState, 'O3', O3m, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to O3!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( aIR, HcoState, 'PH2O2', PH2O2m, RC )
+            call HCO_GetPtr( HcoState, 'PH2O2', PH2O2m, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg =  'Cannot get pointer to PH2O2!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( aIR, HcoState, 'JH2O2', JH2O2,  RC )
+            call HCO_GetPtr( HcoState, 'JH2O2', JH2O2,  RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to JH2O2!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_OH',  OH,    RC )
+            call HCO_GetPtr( HcoState, 'GLOBAL_OH',  OH,    RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_OH!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_NO3', NO3,   RC )
+            call HCO_GetPtr( HcoState, 'GLOBAL_NO3', NO3,   RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_NO3!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )
                RETURN
             ENDIF
 
-            CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_HNO3', HNO3, RC )
+            call HCO_GetPtr( HcoState, 'GLOBAL_HNO3', HNO3, RC )
             IF ( RC /= GC_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to GLOBAL_HNO3!'
                CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/tagged_co_mod.F
+++ b/GeosCore/tagged_co_mod.F
@@ -438,7 +438,7 @@
          IDacet   = Ind_( 'COacet'  )
          
          ! Get a pointer to the OH field from the HEMCO list (bmy, 3/11/15)
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'GLOBAL_OH', OH,   RC )
+         call HCO_GetPtr(  HcoState, 'GLOBAL_OH', OH,   RC )
          IF ( RC /= HCO_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GLOBAL_OH!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -446,7 +446,7 @@
          ENDIF
 
          ! Get pointer to strat P(CO) from GMI
-         CALL HCO_GetPtr( am_I_Root, HcoState, 
+         call HCO_GetPtr(  HcoState, 
      &                   'GMI_PROD_CO', GMI_PROD_CO, RC )
          IF ( RC /= HCO_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GMI_PROD_CO!'
@@ -455,7 +455,7 @@
          ENDIF
 
          ! Get pointer to strat L(CO) from GMI
-         CALL HCO_GetPtr( am_I_Root, HcoState, 
+         call HCO_GetPtr(  HcoState, 
      &                   'GMI_LOSS_CO', GMI_LOSS_CO, RC )
          IF ( RC /= HCO_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to GMI_LOSS_CO!'
@@ -465,7 +465,7 @@
             
          ! Get pointer to trop P(CO) from CH4 if needed
          IF ( LPCO_CH4 ) THEN
-            CALL HCO_GetPtr( am_I_Root, HcoState, 
+            call HCO_GetPtr(  HcoState, 
      &                      'PCO_CH4', PCO_CH4, RC )
             IF ( RC /= HCO_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to PCO_CH4!'
@@ -475,7 +475,7 @@
          ENDIF
 
          IF ( LPCO_NMVOC ) THEN
-            CALL HCO_GetPtr( am_I_Root, HcoState, 
+            call HCO_GetPtr(  HcoState, 
      &                      'PCO_NMVOC', PCO_NMVOC, RC )
             IF ( RC /= HCO_SUCCESS ) THEN
                ErrMsg = 'Cannot get pointer to PCO_NMVOC!'
@@ -485,7 +485,7 @@
          ENDIF
 
          ! Get pointer to surface CH4 data
-         CALL HCO_GetPtr( am_I_Root, HcoState,
+         call HCO_GetPtr(  HcoState,
      &                    'NOAA_GMD_CH4', SFC_CH4, RC )
          IF ( RC /= HCO_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to NOAA_GMD_CH4!'

--- a/GeosCore/tagged_o3_mod.F
+++ b/GeosCore/tagged_o3_mod.F
@@ -557,7 +557,7 @@
          ENDIF
 
          ! Get pointer to O3 production
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'O3_PROD', P24H, RC )
+         call HCO_GetPtr(  HcoState, 'O3_PROD', P24H, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to O3_PROD!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -565,7 +565,7 @@
          ENDIF
 
          ! Get pointer to O3 loss
-         CALL HCO_GetPtr( am_I_Root, HcoState, 'O3_LOSS', L24H, RC )
+         call HCO_GetPtr(  HcoState, 'O3_LOSS', L24H, RC )
          IF ( RC /= GC_SUCCESS ) THEN
             ErrMsg = 'Cannot get pointer to O3_LOSS!'
             CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/toms_mod.F
+++ b/GeosCore/toms_mod.F
@@ -234,7 +234,7 @@
       !-----------------------------------------------------------------
       ! Read TOMS O3 columns [dobsons]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'TOMS_O3_COL', TOMS, RC )
+      call HCO_GetPtr(  HcoState, 'TOMS_O3_COL', TOMS, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to field: TOMS_O3_COL'
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -244,7 +244,7 @@
       !-----------------------------------------------------------------
       ! Read TOMS O3 columns first day [dobsons]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'TOMS1_O3_COL', TOMS1, RC )
+      call HCO_GetPtr(  HcoState, 'TOMS1_O3_COL', TOMS1, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to field: TOMS1_O3_COL!'
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -254,7 +254,7 @@
       !-----------------------------------------------------------------
       ! Read TOMS O3 columns last day [dobsons]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'TOMS2_O3_COL', TOMS2, RC )
+      call HCO_GetPtr(  HcoState, 'TOMS2_O3_COL', TOMS2, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to field: TOMS2_O3_COL!'
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -264,7 +264,7 @@
       !-----------------------------------------------------------------
       ! Read d(TOMS)/dt, 1st half of the month [dobsons/day]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState, 'DTOMS1_O3_COL', DTOMS1, RC)
+      call HCO_GetPtr(  HcoState, 'DTOMS1_O3_COL', DTOMS1, RC)
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to field: DTOMS1_O3_COL'
          CALL GC_Error( ErrMsg, RC, ThisLoc )
@@ -274,7 +274,7 @@
       !-----------------------------------------------------------------
       ! Read d(TOMS)/dt, 2nd half of the month [dobsons/day]
       !-----------------------------------------------------------------
-      CALL HCO_GetPtr( am_I_Root, HcoState,'DTOMS2_O3_COL', DTOMS2, RC )
+      call HCO_GetPtr(  HcoState,'DTOMS2_O3_COL', DTOMS2, RC )
       IF ( RC /= GC_SUCCESS ) THEN
          ErrMsg = 'Cannot get pointer to field: DTOMS2_O3_COL!'
          CALL GC_Error( ErrMsg, RC, ThisLoc )

--- a/GeosCore/uvalbedo_mod.F90
+++ b/GeosCore/uvalbedo_mod.F90
@@ -128,7 +128,7 @@ CONTAINS
     Ptr2D => NULL()
 
     ! Get the pointer to the UV albedo data in the HEMCO data structure
-    CALL HCO_GetPtr( am_I_Root, HcoState, 'UV_ALBEDO', Ptr2D, RC, FOUND=FND )
+    call HCO_GetPtr(  HcoState, 'UV_ALBEDO', Ptr2D, RC, FOUND=FND )
 
     ! Trap potential errors
     IF ( RC /= GC_SUCCESS .or. ( .not. FND ) ) THEN

--- a/HEMCO/Core/hco_restart_mod.F90
+++ b/HEMCO/Core/hco_restart_mod.F90
@@ -338,7 +338,7 @@ CONTAINS
     IF ( .NOT. FLD ) THEN
 
        ! Try to get pointer from HEMCO configuration
-       CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(Name), Ptr3D, RC, FILLED=FLD )
+       call HCO_GetPtr(  HcoState, TRIM(Name), Ptr3D, RC, FILLED=FLD )
        IF ( RC /= HCO_SUCCESS ) RETURN
       
        ! Eventually pass data
@@ -494,7 +494,7 @@ CONTAINS
     IF ( .NOT. FLD ) THEN
 
        ! Try to get pointer from HEMCO configuration
-       CALL HCO_GetPtr( am_I_Root, HcoState, TRIM(Name), Ptr2D, RC, FOUND=FLD )
+       call HCO_GetPtr(  HcoState, TRIM(Name), Ptr2D, RC, FOUND=FLD )
        IF ( RC /= HCO_SUCCESS ) RETURN
       
        ! Eventually pass data

--- a/HEMCO/Extensions/hcox_gc_POPs_mod.F90
+++ b/HEMCO/Extensions/hcox_gc_POPs_mod.F90
@@ -290,19 +290,19 @@ CONTAINS
     !=======================================================================
     IF ( HcoClock_First(HcoState%Clock,.TRUE.) ) THEN
 
-       CALL HCO_GetPtr( aIR, HcoState, 'TOT_POP',     Inst%POP_TOT_EM, RC )
+       call HCO_GetPtr( HcoState, 'TOT_POP',     Inst%POP_TOT_EM, RC )
        IF ( RC /= HCO_SUCCESS ) RETURN
 
-       CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_OC',   Inst%C_OC,       RC )
+       call HCO_GetPtr( HcoState, 'GLOBAL_OC',   Inst%C_OC,       RC )
        IF ( RC /= HCO_SUCCESS ) RETURN
 
-       CALL HCO_GetPtr( aIR, HcoState, 'GLOBAL_BC',   Inst%C_BC,       RC )
+       call HCO_GetPtr( HcoState, 'GLOBAL_BC',   Inst%C_BC,       RC )
        IF ( RC /= HCO_SUCCESS ) RETURN
 
-       CALL HCO_GetPtr( aIR, HcoState, 'SURF_POP',    Inst%POP_SURF,   RC )
+       call HCO_GetPtr( HcoState, 'SURF_POP',    Inst%POP_SURF,   RC )
        IF ( RC /= HCO_SUCCESS ) RETURN
 
-       CALL HCO_GetPtr( aIR, HcoState, 'SOIL_CARBON', Inst%F_OC_SOIL,  RC )
+       call HCO_GetPtr( HcoState, 'SOIL_CARBON', Inst%F_OC_SOIL,  RC )
        IF ( RC /= HCO_SUCCESS ) RETURN
 
        ! Convert F_OC_SOIL from kg/m2 to fraction

--- a/HEMCO/Extensions/hcox_megan_mod.F
+++ b/HEMCO/Extensions/hcox_megan_mod.F
@@ -3519,7 +3519,7 @@
       IF ( RC /= HCO_SUCCESS ) RETURN
 
 ! ---> Now compute EF maps for acetone (dbm, 12/2012)
-!     CALL HCO_GetPtr( am_I_Root, HcoState, 'MEGAN_AEF_ACET', AEF_ACET, RC )
+!     call HCO_GetPtr(  HcoState, 'MEGAN_AEF_ACET', AEF_ACET, RC )
 !     IF ( RC /= HCO_SUCCESS ) RETURN
 ! <---
 
@@ -3531,7 +3531,7 @@
          IF ( RC /= HCO_SUCCESS ) RETURN
       
 ! ---> Now compute EF maps for a-pinene and myrcene (dbm, 12/2012)
-!         CALL HCO_GetPtr( am_I_Root, HcoState, 'MEGAN_AEF_APIN',AEF_APIN, RC )
+!         call HCO_GetPtr(  HcoState, 'MEGAN_AEF_APIN',AEF_APIN, RC )
 !         IF ( RC /= HCO_SUCCESS ) RETURN
 ! <---
          CALL HCO_EvalFld( am_I_Root, HcoState, 
@@ -3550,7 +3550,7 @@
          IF ( RC /= HCO_SUCCESS ) RETURN
 
 ! ---> Now compute EF maps for a-pinene and myrcene (dbm, 12/2012)
-!         CALL HCO_GetPtr( am_I_Root, HcoState, 'MEGAN_AEF_MYRC',AEF_MYRC, RC )
+!         call HCO_GetPtr(  HcoState, 'MEGAN_AEF_MYRC',AEF_MYRC, RC )
 !         IF ( RC /= HCO_SUCCESS ) RETURN
 ! <---
 


### PR DESCRIPTION
This update changes the HEMCO subroutines to be compatible with the new HEMCO.

These calls will need to removed anyway in the future under `#ifdef ( MODEL_CESM )`. They're here just to make compiler happy.

Please refer to the PR at your CAM fork (here: https://github.com/fritzt/CAM/pull/1). Thanks!

Haipeng